### PR TITLE
Update gridcoin_netdata_stats.sh

### DIFF
--- a/getinfo/service/gridcoin_netdata_stats.sh
+++ b/getinfo/service/gridcoin_netdata_stats.sh
@@ -2,10 +2,11 @@
 
 if pgrep "gridcoin" > /dev/null
 then
-	grc getinfo > /home/gridcoin/.GridcoinResearch/getinfo.json
-	grc getstakinginfo > /home/gridcoin/.GridcoinResearch/getstakinginfo.json
-	grc getdifficulty > /home/gridcoin/.GridcoinResearch/difficulty.json
-	else
-   #  echo "Gridcoin is not running!"
+    GRCAPP='/usr/bin/gridcoinresearchd'
+    GRCPATH='/home/gridcoin/.GridcoinResearch'
+    "$GRCAPP" getinfo > "$GRCPATH"/getinfo.tmp && mv -f "$GRCPATH"/getinfo.tmp "$GRCPATH"/getinfo.json
+    "$GRCAPP" getstakinginfo > "$GRCPATH"/getstakinginfo.tmp && mv -f "$GRCPATH"/getstakinginfo.tmp "$GRCPATH"/getstakinginfo.json
+    "$GRCAPP" getdifficulty > "$GRCPATH"/difficulty.tmp && mv -f "$GRCPATH"/difficulty.tmp "$GRCPATH"/difficulty.json
+    else
     exit 1
 fi

--- a/getinfo/service/gridcoin_netdata_stats.sh
+++ b/getinfo/service/gridcoin_netdata_stats.sh
@@ -6,7 +6,6 @@ then
     GRCPATH='/home/gridcoin/.GridcoinResearch'
     "$GRCAPP" getinfo > "$GRCPATH"/getinfo.tmp && mv -f "$GRCPATH"/getinfo.tmp "$GRCPATH"/getinfo.json
     "$GRCAPP" getstakinginfo > "$GRCPATH"/getstakinginfo.tmp && mv -f "$GRCPATH"/getstakinginfo.tmp "$GRCPATH"/getstakinginfo.json
-    "$GRCAPP" getdifficulty > "$GRCPATH"/difficulty.tmp && mv -f "$GRCPATH"/difficulty.tmp "$GRCPATH"/difficulty.json
     else
     exit 1
 fi


### PR DESCRIPTION
I understand the whole alias situation and it worked great for the stats.sh with source. through hours and hours of trying to solve the issue. An alias could just cause issues for other people as well and I don't see the benefit for an alias when it simply could be added once per .sh script if any other ones in future come about as well. This also solves the gaps in gridcoin chart.

I've added GRCAPP='' which is the default install location for PPA. I believe its a similar situation for other distributions as well. (correct me if I'm wrong)
I've added GRCPATH='' which is the default install location for the data directory for Gridcoin. (again correct me if I'm wrong)

Having those two variables set can also make it easy for changes to be made with a custom install without having to change multiple lines of code and Also eliminates the issues of setting up an alias. This also makes the lines of code more clean and neat in my opinion.

The gap in charts is caused by the fact that it takes time for gridcoinresearchd to respond (as does any program). So when you perform getinfo > getinfo.json the ">" clears the file out and it remains empty till the reply is written to the file by the process. So when netdata updates the charts every 5 seconds it is consistent however the information being written to the .json files is not as gridcoinresearchd could be busy with another task at hand (takes longer to get the information) thus you get a gap as there is no data in the file.

My proposed solution reduces that chance. I say reduce because there is always going to be a few milliseconds where the file is being replaced. So if a gap ever appears it will be a rare event. The proposed solution copies the results to a .tmp file and then moves the file to the appropriate .json file. The "&&" basically means if A is successfully completed then proceed to B. So once gridcoinresearchd has responded and the result is recorded to the .tmp file it'll proceed to the next step and move it to the .json file. Otherwise it will wait till A is complete. This will leave data in the .json file all the time so that no gap will show in the chart.

mv is faster then cp on local file system. mv is simply renaming the inode structure and cp is creating a new inode structure. 

Any suggestions or other proposals?