### PR TITLE
Fixes for jq, path independence, additional metrics

### DIFF
--- a/getinfo/gridcoin.chart.sh
+++ b/getinfo/gridcoin.chart.sh
@@ -15,6 +15,12 @@ load_priority=1
 # collects this information using its internal plugins.
 gridcoin_enabled=1
 
+# constant declarations go outside the functions
+GRCPATH="$(getent passwd gridcoin | cut -d: -f6)/.GridcoinResearch"
+GRCINFO="${GRCPATH}/getinfo.json"
+GRCSTAKING="${GRCPATH}/getstakinginfo.json"
+GRCGEO="${GRCPATH}/geooutput.json"
+
 gridcoin_check() {
 	# this should return:
 	#  - 0 to enable the chart
@@ -59,9 +65,6 @@ EOF
 }
 
 gridcoin_update() {
-        GRCINFO='/home/gridcoin/.GridcoinResearch/getinfo.json'
-        GRCSTAKING='/home/gridcoin/.GridcoinResearch/getstakinginfo.json'
-        GRCGEO='/home/gridcoin/.GridcoinResearch/geooutput.json'
 	connections=$(jq '.connections' $GRCINFO)
         blocks=$(jq '.blocks' $GRCINFO)
         moneysupply=$(jq '.moneysupply' $GRCINFO)

--- a/getinfo/gridcoin.chart.sh
+++ b/getinfo/gridcoin.chart.sh
@@ -15,42 +15,39 @@ load_priority=1
 # collects this information using its internal plugins.
 gridcoin_enabled=1
 
-# constant declarations go outside the functions
-GRCPATH="$(getent passwd gridcoin | cut -d: -f6)/.GridcoinResearch"
-GRCINFO="${GRCPATH}/getinfo.json"
-GRCSTAKING="${GRCPATH}/getstakinginfo.json"
-GRCGEO="${GRCPATH}/geooutput.json"
-
 gridcoin_check() {
-	# this should return:
-	#  - 0 to enable the chart
-	#  - 1 to disable the chart
+        # this should return:
+        #  - 0 to enable the chart
+        #  - 1 to disable the chart
 
-	if [ ${gridcoin_update_every} -lt 5 ]
-		then
-		# there is no meaning for shorter than 5 seconds
-		# the kernel changes this value every 5 seconds
-		gridcoin_update_every=5
-	fi
+        if [ ${gridcoin_update_every} -lt 5 ]
+                then
+                # there is no meaning for shorter than 5 seconds
+                # the kernel changes this value every 5 seconds
+                gridcoin_update_every=5
+        fi
 
-	[ ${gridcoin_enabled} -eq 0 ] && return 1
-	return 0
+        [ ${gridcoin_enabled} -eq 0 ] && return 1
+        return 0
 }
 
 gridcoin_create() {
-        # create a chart with 3 dimensions
 cat <<EOF
 CHART Gridcoin.connections '' "Gridcoin client connections" "# of connections" Connections gridcoin.connections line $((load_priority + 1)) $gridcoin_update_every
 DIMENSION connections 'Connected' absolute 1 1
 CHART Gridcoin.blocks '' "Gridcoin blocks" "# of blocks" Blocks gridcoin.blocks line $((load_priority + 1)) $gridcoin_update_every
 DIMENSION blocks 'Blocks' absolute 1 1
+CHART Gridcoin.superblock_age '' "Gridcoin superblock age" "hours" Superblock_Age gridcoin.superblock_age line $((load_priority + 1)) $gridcoin_update_every
+DIMENSION superblock_age 'Hours' absolute 1 3600
 CHART Gridcoin.money '' "Gridcoin coin supply" "Total coin supply" Coin_Supply gridcoin.money line $((load_priority + 1)) $gridcoin_update_every
 DIMENSION moneysupply 'Coins' absolute 1 1
 CHART Gridcoin.difficulty '' "Gridcoin difficulties" "Difficulty" Difficulties gridcoin.difficulty line $((load_priority + 1)) $gridcoin_update_every
 DIMENSION difficultypos 'PoS' absolute 1 1
 DIMENSION difficultypow 'PoW' absolute 1 1
-CHART Gridcoin.stake_weight '' "Gridcoin network weight" "# of coins staking" Network_Weight gridcoin.stake_weight line $((load_priority + 1)) $gridcoin_update_every
-DIMENSION stakeweight 'Weight' absolute 1 1
+DIMENSION difficultypor 'PoR' absolute 1 1
+CHART Gridcoin.stake_weight '' "Gridcoin stake weight" "# of coins staking" Network_Weight gridcoin.stake_weight line $((load_priority + 1)) $gridcoin_update_every
+DIMENSION net_weight 'Net Weight' absolute 1 1
+DIMENSION dpor_weight 'DPoR Weight' absolute 1 100000000
 CHART Gridcoin.continent '' "Gridcoin client locations" "# of connections from" Locations gridcoin.continent stacked $((load_priority + 1)) $gridcoin_update_every
 DIMENSION northamerica 'N. America' absolute 1 1
 DIMENSION southamerica 'S. America' absolute 1 1
@@ -59,18 +56,49 @@ DIMENSION africa 'Africa' absolute 1 1
 DIMENSION asia 'Asia' absolute 1 1
 DIMENSION oceania 'Oceania' absolute 1 1
 DIMENSION other 'Other' absolute 1 1
+CHART Gridcoin.timeoffset '' "Gridcoin node time offset" "milliseconds" Time_Offset gridcoin.timeoffset line $((load_priority + 1)) $gridcoin_update_every
+DIMENSION timeoffset 'Delta' absolute 1 1
+CHART Gridcoin.transactions '' "Gridcoin transactions" "# of transactions" Transactions gridcoin.transactions line $((load_priority + 1)) $gridcoin_update_every
+DIMENSION currentblocktx 'TX current block' absolute 1 1
+DIMENSION pooledtx 'TX pooled' absolute 1 1
+CHART Gridcoin.rsa '' "Gridcoin research savings account" "GRC" RSA gridcoin.rsa line $((load_priority + 1)) $gridcoin_update_every
+DIMENSION paid_daily 'Paid daily' absolute 1 1
+DIMENSION paid_14days 'Paid 14 days' absolute 1 1
+DIMENSION exp_daily 'Expected daily' absolute 1 1
+DIMENSION exp_14days 'Expected 14 days' absolute 1 1
+CHART Gridcoin.fulfillment '' "Gridcoin fulfillment" "percent" Fulfillment gridcoin.fulfillment line $((load_priority + 1)) $gridcoin_update_every
+DIMENSION fulfillment '% Fulfilled' absolute 1 1
+CHART Gridcoin.magnitude '' "Gridcoin magnitude" "mag" Magnitude gridcoin.magnitude line $((load_priority + 1)) $gridcoin_update_every
+DIMENSION magnitude 'Magnitude' absolute 1 1
+CHART Gridcoin.magnitude_unit '' "Gridcoin magnitude unit" "coins per unit mag" Magnitude_Unit gridcoin.magnitude_unit line $((load_priority + 1)) $gridcoin_update_every
+DIMENSION magnitude_unit 'Mag Unit' absolute 1 1000
+CHART Gridcoin.lifetime '' "Gridcoin lifetime performance" "GRC" Lifetime gridcoin.lifetime stacked $((load_priority + 1)) $gridcoin_update_every
+DIMENSION lifetime_interest 'Interest' absolute 1 1
+DIMENSION lifetime_research 'Research' absolute 1 1
+CHART Gridcoin.lifetime_ppd '' "Gridcoin lifetime payments per day" "GRC" Lifetime_Average gridcoin.lifetime_ppd line $((load_priority + 1)) $gridcoin_update_every
+DIMENSION lifetime_ppd 'PPD' absolute 1 1
 EOF
 
         return 0
 }
 
 gridcoin_update() {
-	connections=$(jq '.connections' $GRCINFO)
+        GRCPATH="$(getent passwd gridcoin | cut -d: -f6)/.GridcoinResearch"
+        GRCINFO="${GRCPATH}/getinfo.json"
+        GRCSTAKING="${GRCPATH}/getstakinginfo.json"
+        GRCMINING="${GRCPATH}/getmininginfo.json"
+        GRCMAGNITUDE="${GRCPATH}/listmymagnitude.json"
+        GRCSB="${GRCPATH}/executesuperblockage.json"
+        GRCGEO="${GRCPATH}/geooutput.json"
+        connections=$(jq '.connections' $GRCINFO)
         blocks=$(jq '.blocks' $GRCINFO)
+        superblock_age=$(jq -r '.[1]."Superblock Age"' $GRCSB)
         moneysupply=$(jq '.moneysupply' $GRCINFO)
-        difficulty_pow=$(jq '.difficulty["proof-of-work"]' $GRCINFO)
-        difficulty_pos=$(jq '.difficulty["proof-of-stake"]' $GRCINFO)
+        difficulty_pow=$(jq '.difficulty["proof-of-work"]' $GRCMINING)
+        difficulty_pos=$(jq '.difficulty["proof-of-stake"]' $GRCMINING)
+        difficulty_por=$(jq '.difficulty["proof-of-research"]' $GRCMINING)
         staking_weight=$(jq '.netstakeweight' $GRCSTAKING)
+        dpor_weight=$(jq '.weight' $GRCSTAKING)
         geoNA=$(jq -r '.[].contNA' $GRCGEO)
         geoSA=$(jq -r '.[].contSA' $GRCGEO)
         geoEU=$(jq -r '.[].contEU' $GRCGEO)
@@ -78,7 +106,21 @@ gridcoin_update() {
         geoAS=$(jq -r '.[].contAS' $GRCGEO)
         geoOC=$(jq -r '.[].contOC' $GRCGEO)
         geoOT=$(jq -r '.[].contOT' $GRCGEO)
-	# write the result of the work.
+        timeoffset=$(jq -r '.timeoffset' $GRCINFO)
+        currentblocktx=$(jq -r '.currentblocktx' $GRCSTAKING)
+        pooledtx=$(jq -r '.pooledtx' $GRCSTAKING)
+        paid_daily=$(jq -r '.[1]."Daily Paid"' $GRCMAGNITUDE)
+        paid_fortnightly=$(jq -r '.[1]."Research Payments (14 days)"' $GRCMAGNITUDE)
+        exp_daily=$(jq -r '.[1]."Expected Earnings (Daily)"' $GRCMAGNITUDE)
+        exp_fortnightly=$(jq -r '.[1]."Expected Earnings (14 days)"' $GRCMAGNITUDE)
+        fulfillment=$(jq -r '.[1]."Fulfillment %"' $GRCMAGNITUDE)
+        magnitude=$(jq -r '.[1]."Magnitude (Last Superblock)"' $GRCMAGNITUDE)
+        magnitude_unit=$(jq -r '."Magnitude Unit"' $GRCMINING | sed -r "s/0?\.//")
+        lifetime_interest=$(jq -r '.[1]."CPID Lifetime Interest Paid"' $GRCMAGNITUDE)
+        lifetime_research=$(jq -r '.[1]."CPID Lifetime Research Paid"' $GRCMAGNITUDE)
+        lifetime_avg_mag=$(jq -r '.[1]."CPID Lifetime Avg Magnitude"' $GRCMAGNITUDE)
+        lifetime_ppd=$(jq -r '.[1]."CPID Lifetime Payments Per Day"' $GRCMAGNITUDE)
+        # write the result of the work.
         cat <<VALUESEOF
 BEGIN Gridcoin.connections
 SET connections = $connections
@@ -86,15 +128,20 @@ END
 BEGIN Gridcoin.blocks
 SET blocks = $blocks
 END
+BEGIN Gridcoin.superblock_age
+SET superblock_age = $superblock_age
+END
 BEGIN Gridcoin.money
 SET moneysupply = $moneysupply
 END
 BEGIN Gridcoin.difficulty
 SET difficultypos = $difficulty_pos
 SET difficultypow = $difficulty_pow
+SET difficultypor = $difficulty_por
 END
 BEGIN Gridcoin.stake_weight
-SET stakeweight = $staking_weight
+SET net_weight = $staking_weight
+SET dpor_weight = $dpor_weight
 END
 BEGIN Gridcoin.continent
 SET northamerica = $geoNA
@@ -104,6 +151,35 @@ SET africa = $geoAF
 SET asia = $geoAS
 SET oceania = $geoOC
 SET other = $geoOT
+END
+BEGIN Gridcoin.timeoffset
+SET timeoffset = $timeoffset
+END
+BEGIN Gridcoin.transactions
+SET currentblocktx = $currentblocktx
+SET pooledtx = $pooledtx
+END
+BEGIN Gridcoin.rsa
+SET paid_daily = $paid_daily
+SET paid_14days = $paid_fortnightly
+SET exp_daily = $exp_daily
+SET exp_14days = $exp_fortnightly
+END
+BEGIN Gridcoin.fulfillment
+SET fulfillment = $fulfillment
+END
+BEGIN Gridcoin.magnitude
+SET magnitude = $magnitude
+END
+BEGIN Gridcoin.magnitude_unit
+SET magnitude_unit = $magnitude_unit
+END
+BEGIN Gridcoin.lifetime
+SET lifetime_interest = $lifetime_interest
+SET lifetime_research = $lifetime_research
+END
+BEGIN Gridcoin.lifetime_ppd
+SET lifetime_ppd = $lifetime_ppd
 END
 VALUESEOF
 

--- a/getinfo/gridcoin.chart.sh
+++ b/getinfo/gridcoin.chart.sh
@@ -47,7 +47,6 @@ DIMENSION difficultypow 'PoW' absolute 1 1
 DIMENSION difficultypor 'PoR' absolute 1 1
 CHART Gridcoin.stake_weight '' "Gridcoin stake weight" "# of coins staking" Network_Weight gridcoin.stake_weight line $((load_priority + 1)) $gridcoin_update_every
 DIMENSION net_weight 'Net Weight' absolute 1 1
-DIMENSION dpor_weight 'DPoR Weight' absolute 1 100000000
 CHART Gridcoin.continent '' "Gridcoin client locations" "# of connections from" Locations gridcoin.continent stacked $((load_priority + 1)) $gridcoin_update_every
 DIMENSION northamerica 'N. America' absolute 1 1
 DIMENSION southamerica 'S. America' absolute 1 1
@@ -56,7 +55,7 @@ DIMENSION africa 'Africa' absolute 1 1
 DIMENSION asia 'Asia' absolute 1 1
 DIMENSION oceania 'Oceania' absolute 1 1
 DIMENSION other 'Other' absolute 1 1
-CHART Gridcoin.timeoffset '' "Gridcoin node time offset" "milliseconds" Time_Offset gridcoin.timeoffset line $((load_priority + 1)) $gridcoin_update_every
+CHART Gridcoin.timeoffset '' "Gridcoin node time offset" "minutes" Time_Offset gridcoin.timeoffset line $((load_priority + 1)) $gridcoin_update_every
 DIMENSION timeoffset 'Delta' absolute 1 1
 CHART Gridcoin.transactions '' "Gridcoin transactions" "# of transactions" Transactions gridcoin.transactions line $((load_priority + 1)) $gridcoin_update_every
 DIMENSION currentblocktx 'TX current block' absolute 1 1
@@ -66,10 +65,12 @@ DIMENSION paid_daily 'Paid daily' absolute 1 1
 DIMENSION paid_14days 'Paid 14 days' absolute 1 1
 DIMENSION exp_daily 'Expected daily' absolute 1 1
 DIMENSION exp_14days 'Expected 14 days' absolute 1 1
+DIMENSION rsa_owed 'RSA Owed' absolute 1 1
 CHART Gridcoin.fulfillment '' "Gridcoin fulfillment" "percent" Fulfillment gridcoin.fulfillment line $((load_priority + 1)) $gridcoin_update_every
 DIMENSION fulfillment '% Fulfilled' absolute 1 1
-CHART Gridcoin.magnitude '' "Gridcoin magnitude" "mag" Magnitude gridcoin.magnitude line $((load_priority + 1)) $gridcoin_update_every
+CHART Gridcoin.magnitude '' "Gridcoin magnitude" "mag" Magnitude gridcoin.magnitude stacked $((load_priority + 1)) $gridcoin_update_every
 DIMENSION magnitude 'Magnitude' absolute 1 1
+DIMENSION dpor_weight 'DPoR Weight' absolute 1 100000000
 CHART Gridcoin.magnitude_unit '' "Gridcoin magnitude unit" "coins per unit mag" Magnitude_Unit gridcoin.magnitude_unit line $((load_priority + 1)) $gridcoin_update_every
 DIMENSION magnitude_unit 'Mag Unit' absolute 1 1000
 CHART Gridcoin.lifetime '' "Gridcoin lifetime performance" "GRC" Lifetime gridcoin.lifetime stacked $((load_priority + 1)) $gridcoin_update_every
@@ -88,6 +89,7 @@ gridcoin_update() {
         GRCSTAKING="${GRCPATH}/getstakinginfo.json"
         GRCMINING="${GRCPATH}/getmininginfo.json"
         GRCMAGNITUDE="${GRCPATH}/listmymagnitude.json"
+        GRCRSA="$GRCPATH/listrsaweight.json"
         GRCSB="${GRCPATH}/executesuperblockage.json"
         GRCGEO="${GRCPATH}/geooutput.json"
         connections=$(jq '.connections' $GRCINFO)
@@ -113,6 +115,7 @@ gridcoin_update() {
         paid_fortnightly=$(jq -r '.[1]."Research Payments (14 days)"' $GRCMAGNITUDE)
         exp_daily=$(jq -r '.[1]."Expected Earnings (Daily)"' $GRCMAGNITUDE)
         exp_fortnightly=$(jq -r '.[1]."Expected Earnings (14 days)"' $GRCMAGNITUDE)
+        rsa_owed=$(jq -r '.[1]."RSA Owed"' $GRCRSA)
         fulfillment=$(jq -r '.[1]."Fulfillment %"' $GRCMAGNITUDE)
         magnitude=$(jq -r '.[1]."Magnitude (Last Superblock)"' $GRCMAGNITUDE)
         magnitude_unit=$(jq -r '."Magnitude Unit"' $GRCMINING | sed -r "s/0?\.//")
@@ -141,7 +144,6 @@ SET difficultypor = $difficulty_por
 END
 BEGIN Gridcoin.stake_weight
 SET net_weight = $staking_weight
-SET dpor_weight = $dpor_weight
 END
 BEGIN Gridcoin.continent
 SET northamerica = $geoNA
@@ -164,12 +166,14 @@ SET paid_daily = $paid_daily
 SET paid_14days = $paid_fortnightly
 SET exp_daily = $exp_daily
 SET exp_14days = $exp_fortnightly
+SET rsa_owed = $rsa_owed
 END
 BEGIN Gridcoin.fulfillment
 SET fulfillment = $fulfillment
 END
 BEGIN Gridcoin.magnitude
 SET magnitude = $magnitude
+SET dpor_weight = $dpor_weight
 END
 BEGIN Gridcoin.magnitude_unit
 SET magnitude_unit = $magnitude_unit

--- a/getinfo/gridcoin.chart.sh
+++ b/getinfo/gridcoin.chart.sh
@@ -38,7 +38,7 @@ DIMENSION connections 'Connected' absolute 1 1
 CHART Gridcoin.blocks '' "Gridcoin blocks" "# of blocks" Blocks gridcoin.blocks line $((load_priority + 1)) $gridcoin_update_every
 DIMENSION blocks 'Blocks' absolute 1 1
 CHART Gridcoin.superblock_age '' "Gridcoin superblock age" "hours" Superblock_Age gridcoin.superblock_age line $((load_priority + 1)) $gridcoin_update_every
-DIMENSION superblock_age 'Hours' absolute 1 3600
+DIMENSION superblock_age 'Age' absolute 1 3600
 CHART Gridcoin.money '' "Gridcoin coin supply" "Total coin supply" Coin_Supply gridcoin.money line $((load_priority + 1)) $gridcoin_update_every
 DIMENSION moneysupply 'Coins' absolute 1 1
 CHART Gridcoin.difficulty '' "Gridcoin difficulties" "Difficulty" Difficulties gridcoin.difficulty line $((load_priority + 1)) $gridcoin_update_every
@@ -47,7 +47,7 @@ DIMENSION difficultypow 'PoW' absolute 1 1
 DIMENSION difficultypor 'PoR' absolute 1 1
 CHART Gridcoin.stake_weight '' "Gridcoin stake weight" "# of coins staking" Network_Weight gridcoin.stake_weight line $((load_priority + 1)) $gridcoin_update_every
 DIMENSION net_weight 'Net Weight' absolute 1 1
-CHART Gridcoin.continent '' "Gridcoin client locations" "# of connections from" Locations gridcoin.continent stacked $((load_priority + 1)) $gridcoin_update_every
+CHART Gridcoin.continent '' "Gridcoin client locations" "# of connections from" Client_Locations gridcoin.continent stacked $((load_priority + 1)) $gridcoin_update_every
 DIMENSION northamerica 'N. America' absolute 1 1
 DIMENSION southamerica 'S. America' absolute 1 1
 DIMENSION europe 'Europe' absolute 1 1
@@ -76,8 +76,10 @@ DIMENSION magnitude_unit 'Mag Unit' absolute 1 1000
 CHART Gridcoin.lifetime '' "Gridcoin lifetime performance" "GRC" Lifetime gridcoin.lifetime stacked $((load_priority + 1)) $gridcoin_update_every
 DIMENSION lifetime_interest 'Interest' absolute 1 1
 DIMENSION lifetime_research 'Research' absolute 1 1
-CHART Gridcoin.lifetime_ppd '' "Gridcoin lifetime payments per day" "GRC" Lifetime_Average gridcoin.lifetime_ppd line $((load_priority + 1)) $gridcoin_update_every
+CHART Gridcoin.lifetime_ppd '' "Gridcoin lifetime payments per day" "GRC" Lifetime_Average_Payments gridcoin.lifetime_ppd line $((load_priority + 1)) $gridcoin_update_every
 DIMENSION lifetime_ppd 'PPD' absolute 1 1
+CHART Gridcoin.neural_network '' "Gridcoin neural network" "weight" Neural_Network gridcoin.neural_network line $((load_priority + 1)) $gridcoin_update_every
+DIMENSION neural_popularity 'Popularity' absolute 1 1
 EOF
 
         return 0
@@ -99,6 +101,7 @@ gridcoin_update() {
         difficulty_pow=$(jq '.difficulty["proof-of-work"]' $GRCMINING)
         difficulty_pos=$(jq '.difficulty["proof-of-stake"]' $GRCMINING)
         difficulty_por=$(jq '.difficulty["proof-of-research"]' $GRCMINING)
+        neural_popularity=$(jq '.NeuralPopularity' $GRCMINING)
         staking_weight=$(jq '.netstakeweight' $GRCSTAKING)
         dpor_weight=$(jq '.weight' $GRCSTAKING)
         geoNA=$(jq -r '.[].contNA' $GRCGEO)
@@ -184,6 +187,9 @@ SET lifetime_research = $lifetime_research
 END
 BEGIN Gridcoin.lifetime_ppd
 SET lifetime_ppd = $lifetime_ppd
+END
+BEGIN Gridcoin.neural_network
+SET neural_popularity = $neural_popularity
 END
 VALUESEOF
 

--- a/getinfo/service/gridcoin_geo_scrape.service
+++ b/getinfo/service/gridcoin_geo_scrape.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run the collection script for the gridcoin geographic scrape chart
+Description=Gridcoin geo data collection
 After=netdata.service
 
 [Service]

--- a/getinfo/service/gridcoin_geo_scrape.sh
+++ b/getinfo/service/gridcoin_geo_scrape.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash
 
 #--------------------------------------------------
 # This script intended to run as service addition to gridcoin_netdata or as a seperate service if more charts are added

--- a/getinfo/service/gridcoin_geo_scrape.sh
+++ b/getinfo/service/gridcoin_geo_scrape.sh
@@ -24,7 +24,7 @@
 # SET enviroment variables
 
 APIADDRESS='http://127.0.0.1:5000/json'
-GRCAPP="$(which gridcoind)"
+GRCAPP="$(which gridcoinresearchd)"
 GRCPATH="$(getent passwd gridcoin | cut -d: -f6)/.GridcoinResearch"
 GRCALIAS="sudo -u gridcoin ${GRCAPP} -datadir=${GRCPATH}"
 

--- a/getinfo/service/gridcoin_netdata_stats.service
+++ b/getinfo/service/gridcoin_netdata_stats.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Run the collection script for the gridcoin netdata charts
+Description=Gridcoin netdata stats collection
 After=netdata.service
 
 [Service]

--- a/getinfo/service/gridcoin_netdata_stats.sh
+++ b/getinfo/service/gridcoin_netdata_stats.sh
@@ -8,6 +8,7 @@ then
     "$GRCAPP" getstakinginfo > "$GRCPATH"/getstakinginfo.tmp && mv -f "$GRCPATH"/getstakinginfo.tmp "$GRCPATH"/getstakinginfo.json
     "$GRCAPP" getmininginfo > "$GRCPATH"/getmininginfo.tmp && mv -f "$GRCPATH"/getmininginfo.tmp "$GRCPATH"/getmininginfo.json
     "$GRCAPP" list mymagnitude > "$GRCPATH"/listmymagnitude.tmp && mv -f "$GRCPATH"/listmymagnitude.tmp "$GRCPATH"/listmymagnitude.json
+    "$GRCAPP" list rsaweight > "$GRCPATH"/listrsaweight.tmp && mv -f "$GRCPATH"/listrsaweight.tmp "$GRCPATH"/listrsaweight.json
     "$GRCAPP" execute superblockage > "$GRCPATH"/executesuperblockage.tmp && mv -f "$GRCPATH"/executesuperblockage.tmp "$GRCPATH"/executesuperblockage.json
     else
     exit 1

--- a/getinfo/service/gridcoin_netdata_stats.sh
+++ b/getinfo/service/gridcoin_netdata_stats.sh
@@ -6,6 +6,9 @@ then
     GRCPATH="$(getent passwd gridcoin | cut -d: -f6)/.GridcoinResearch"
     "$GRCAPP" getinfo > "$GRCPATH"/getinfo.tmp && mv -f "$GRCPATH"/getinfo.tmp "$GRCPATH"/getinfo.json
     "$GRCAPP" getstakinginfo > "$GRCPATH"/getstakinginfo.tmp && mv -f "$GRCPATH"/getstakinginfo.tmp "$GRCPATH"/getstakinginfo.json
+    "$GRCAPP" getmininginfo > "$GRCPATH"/getmininginfo.tmp && mv -f "$GRCPATH"/getmininginfo.tmp "$GRCPATH"/getmininginfo.json
+    "$GRCAPP" list mymagnitude > "$GRCPATH"/listmymagnitude.tmp && mv -f "$GRCPATH"/listmymagnitude.tmp "$GRCPATH"/listmymagnitude.json
+    "$GRCAPP" execute superblockage > "$GRCPATH"/executesuperblockage.tmp && mv -f "$GRCPATH"/executesuperblockage.tmp "$GRCPATH"/executesuperblockage.json
     else
     exit 1
 fi

--- a/getinfo/service/gridcoin_netdata_stats.sh
+++ b/getinfo/service/gridcoin_netdata_stats.sh
@@ -2,7 +2,7 @@
 
 if pgrep "gridcoin" > /dev/null
 then
-    GRCAPP="$(which gridcoind)"
+    GRCAPP="$(which gridcoinresearchd)"
     GRCPATH="$(getent passwd gridcoin | cut -d: -f6)/.GridcoinResearch"
     "$GRCAPP" getinfo > "$GRCPATH"/getinfo.tmp && mv -f "$GRCPATH"/getinfo.tmp "$GRCPATH"/getinfo.json
     "$GRCAPP" getstakinginfo > "$GRCPATH"/getstakinginfo.tmp && mv -f "$GRCPATH"/getstakinginfo.tmp "$GRCPATH"/getstakinginfo.json

--- a/getinfo/service/gridcoin_netdata_stats.sh
+++ b/getinfo/service/gridcoin_netdata_stats.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
 if pgrep "gridcoin" > /dev/null
 then
-    GRCAPP='/usr/bin/gridcoinresearchd'
-    GRCPATH='/home/gridcoin/.GridcoinResearch'
+    GRCAPP="$(which gridcoind)"
+    GRCPATH="$(getent passwd gridcoin | cut -d: -f6)/.GridcoinResearch"
     "$GRCAPP" getinfo > "$GRCPATH"/getinfo.tmp && mv -f "$GRCPATH"/getinfo.tmp "$GRCPATH"/getinfo.json
     "$GRCAPP" getstakinginfo > "$GRCPATH"/getstakinginfo.tmp && mv -f "$GRCPATH"/getstakinginfo.tmp "$GRCPATH"/getstakinginfo.json
     else

--- a/getinfo/service/setup_service.sh
+++ b/getinfo/service/setup_service.sh
@@ -45,8 +45,8 @@ function serviceinstall {
         echo Extracting freegeoip from archive..
         tar -zxf freegeoip-3.2-linux-amd64.tar.gz freegeoip-3.2-linux-amd64/freegeoip
         echo Making crontab bootup entry under user gridcoin..
-        echo Warning: If you have run this install more then once then crontab -u gridcoin -e and make sure there is no duplicate entry for freegeoip
-        crontab -l -u gridcoin | cat - freegeoip.crontab | crontab -u gridcoin -
+        crontab_contains_freegeoip="$(crontab -l -u gridcoin | grep freegeoip)"
+        [[ ${crontab_contains_freegeoip} -lt 1 ]] && crontab -l -u gridcoin | cat - freegeoip.crontab | crontab -u gridcoin -
         echo Copying license file..
         cp ./freegeoip.license /usr/local/bin/freegeoip.license
         echo Copying freegeoip binary..

--- a/getinfo/service/setup_service.sh
+++ b/getinfo/service/setup_service.sh
@@ -21,7 +21,6 @@ function serviceinstall {
         # Make chart and script executable
         echo Making .sh files executable..
         chmod +x /usr/local/bin/gridcoin_netdata_stats.sh
-        chmod +x /usr/libexec/netdata/charts.d/gridcoin.chart.sh
 
         # Part 2
         #
@@ -41,11 +40,11 @@ function serviceinstall {
         # Copy freegeoip service, binary and license file
         # Service not supported as doesn't run as daemon nor can be forced with systemctl
         echo Downloading freegeoip version 3.2 amd64..
-        wget https://github.com/fiorix/freegeoip/releases/download/v3.2/freegeoip-3.2-linux-amd64.tar.gz
+        curl -L -O https://github.com/fiorix/freegeoip/releases/download/v3.2/freegeoip-3.2-linux-amd64.tar.gz
         echo Extracting freegeoip from archive..
         tar -zxf freegeoip-3.2-linux-amd64.tar.gz freegeoip-3.2-linux-amd64/freegeoip
         echo Making crontab bootup entry under user gridcoin..
-        crontab_contains_freegeoip="$(crontab -l -u gridcoin | grep freegeoip)"
+        crontab_contains_freegeoip="$(crontab -l -u gridcoin | grep -c freegeoip)"
         [[ ${crontab_contains_freegeoip} -lt 1 ]] && crontab -l -u gridcoin | cat - freegeoip.crontab | crontab -u gridcoin -
         echo Copying license file..
         cp ./freegeoip.license /usr/local/bin/freegeoip.license


### PR DESCRIPTION
I've made a few changes in my own fork that I think may be helpful. If the maintainers would like me to refactor the proposed commits differently, I'd be happy to rework this on another branch.

The following changelog applies only to the `getinfo/` tree of the repository:
- Wherever the path to the `.GridcoinResearch/` directory is required, `${GRCPATH}` is set using `getent passwd gridcoin` and automatically set to the correct absolute path based on the user's actual home folder.
- Some whitespace cleanup and string safety quotations.
- Several additional wallet metrics (magnitude, RSA values, lifetime totals, superblock age, DPoR weight, etc.)
- Improved the systemd service installer to be more idempotent. It will no longer:
  - try to add a crontab entry for freegeoip if one already exists
  - create a new tarball for the freegeoip distfiles for each installation (it will overwrite any existing one instead)
  - `chmod +x` the `netdata/charts.d/` script (it doesn't need to be, and shouldn't be, executable; it's included in memory when netdata sources it)
- `jq` no longer chokes on:
  - IPv6 addresses when passing them to freegeoip
  - null country codes (really)
- A few conservative cosmetic tweaks (e.g., easier-to-read systemd unit descriptions for the timers when they appear in your journal every 5sec)
